### PR TITLE
Zeroize Sensitive Types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4255,6 +4255,7 @@ dependencies = [
  "tokio",
  "url",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -5300,6 +5301,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio"] }
 tokio = { version = "1.46", features = ["full"] }
 url = "2.5"
 uuid = { version = "1.17", features = ["v7"] }
+zeroize = { version = "1.8", features = ["derive"] }
 
 # CLI Dependencies
 clap = { version = "4.5", features = ["derive"] }

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -247,6 +247,9 @@ fn test_path_parse() {
 fn get_password() -> Password {
     print!("Password: ");
     io::stdout().flush().ok();
-    // TODO: Is there a better way to try to hide the password in memory?
+    // TODO: Can we write our own STDIN reader which avoids allocation
+    // altogether by disabling the buffered input (raw mode) and copies each
+    // input character into a fixed length buffer. Maximum password lengths
+    // could be something like 200 characters.
     rpassword::read_password().unwrap().into()
 }

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -244,9 +244,9 @@ fn test_path_parse() {
 }
 
 // TODO: Error handling.
-fn get_password() -> String {
+fn get_password() -> Password {
     print!("Password: ");
     io::stdout().flush().ok();
     // TODO: Is there a better way to try to hide the password in memory?
-    rpassword::read_password().unwrap()
+    rpassword::read_password().unwrap().into()
 }

--- a/src/bin/gui.rs
+++ b/src/bin/gui.rs
@@ -32,7 +32,7 @@ struct ValetApp {
 
     // TODO: This should be it's own widget.
     username: String,
-    password: String,
+    password: Password,
     show_password: bool,
     login_inbox: UiInbox<User>,
 
@@ -59,7 +59,7 @@ impl ValetApp {
             user: None,
 
             username: "".into(),
-            password: "".into(),
+            password: Password::empty(),
             show_password: false,
             login_inbox: UiInbox::new(),
 
@@ -128,7 +128,7 @@ impl eframe::App for ValetApp {
                 if let Some(user) = self.login_inbox.read(ui).last() {
                     self.user = Some(Arc::new(user));
                     // TODO: Do we clear the username or not?
-                    self.password = "".into();
+                    self.password = Password::empty();
                     self.show_password = false;
                 }
 
@@ -136,7 +136,8 @@ impl eframe::App for ValetApp {
                 let username_re = ui.add(egui::TextEdit::singleline(&mut self.username));
                 ui.label("Password:");
                 let password_re = ui.add(
-                    egui::TextEdit::singleline(&mut self.password).password(!self.show_password),
+                    egui::TextEdit::singleline(&mut self.password.as_str())
+                        .password(!self.show_password),
                 );
                 ui.checkbox(&mut self.show_password, "Show password");
                 ui.add_space(5.);

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -81,7 +81,6 @@ impl Key {
         Key(Aes256SivAead::generate_key(&mut OsRng))
     }
 
-    // TODO: Zeroize password
     pub fn from_password(password: Password, salt: &[u8]) -> Result<Self, Error> {
         let argon2 = Argon2::default();
         let mut output_key_material = [0u8; <Aes256SivAead as KeySizeUser>::KeySize::USIZE];

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -71,7 +71,7 @@ pub struct Encrypted {
 /// Aes256 has a 512-bit key size, and achieves 256-bit security.
 //
 // TODO: #6 keys should not be clonable.
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Zeroize, ZeroizeOnDrop)]
 pub struct Key(AesKey<Aes256SivAead>);
 
 impl Key {

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -8,7 +8,9 @@ use rand_core::{OsRng, RngCore};
 use std::{ops::Deref, pin::Pin};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-/// A safe wrapper for plaintext password strings.
+/// A safer wrapper for plaintext password strings.
+///
+/// This structure both pins it's reference and zeros the memory on drop.
 //
 // TODO: Is there a way in the GUI to avoid cloning the password to send it to
 // a async function?

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -21,7 +21,7 @@ pub struct Encrypted {
 /// Aes256 has a 512-bit key size, and achieves 256-bit security.
 //
 // TODO: #6 keys should not be clonable.
-#[derive(PartialEq, Eq, Clone)]
+#[derive(PartialEq, Eq)]
 pub struct Key(AesKey<Aes256SivAead>);
 
 impl Key {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,5 @@
 pub use crate::db::Database;
+pub use crate::encrypt::Password;
 pub use crate::lot::{DEFAULT_LOT, Lot};
 pub use crate::record::{Record, RecordData};
 pub use crate::user::User;

--- a/src/user.rs
+++ b/src/user.rs
@@ -2,7 +2,7 @@ use std::{fmt::Debug, fmt::Formatter, ops::Deref};
 
 use crate::{
     db::{self, Database},
-    encrypt::{self, Encrypted, Key, SALT_SIZE},
+    encrypt::{self, Encrypted, Key, Password, SALT_SIZE},
     lot::{self, Lot},
 };
 
@@ -22,7 +22,7 @@ pub struct User {
 
 impl User {
     // TODO: Zeroize password
-    pub fn new(username: &str, password: String) -> Result<Self, Error> {
+    pub fn new(username: &str, password: Password) -> Result<Self, Error> {
         let salt = Key::generate_salt();
         let key = UserKey(Key::from_password(password, &salt)?);
         let validation = key.encrypt(VALIDATION)?;
@@ -63,7 +63,7 @@ impl User {
     }
 
     // TODO: Zeroize password
-    pub async fn load(db: &Database, username: &str, password: String) -> Result<Self, Error> {
+    pub async fn load(db: &Database, username: &str, password: Password) -> Result<Self, Error> {
         let sql_user = db::users::SqlUser::select(&db, &username).await?;
         let key = UserKey(Key::from_password(password, &sql_user.salt[..])?);
         let validation = Encrypted {
@@ -201,14 +201,14 @@ mod tests {
             .await
             .expect("failed to create database");
 
-        let password = "password".to_string();
-        let user = User::new("alice", password.clone())
+        let password = "password";
+        let user = User::new("alice", password.into())
             .expect("failed to create user")
             .register(&db)
             .await
             .expect("failed to register user");
 
-        let loaded = User::load(&db, &user.username, password)
+        let loaded = User::load(&db, &user.username, password.into())
             .await
             .expect("failed to load user");
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -21,7 +21,6 @@ pub struct User {
 }
 
 impl User {
-    // TODO: Zeroize password
     pub fn new(username: &str, password: Password) -> Result<Self, Error> {
         let salt = Key::generate_salt();
         let key = UserKey(Key::from_password(password, &salt)?);
@@ -62,7 +61,6 @@ impl User {
         Ok(self)
     }
 
-    // TODO: Zeroize password
     pub async fn load(db: &Database, username: &str, password: Password) -> Result<Self, Error> {
         let sql_user = db::users::SqlUser::select(&db, &username).await?;
         let key = UserKey(Key::from_password(password, &sql_user.salt[..])?);


### PR DESCRIPTION
Using the https://docs.rs/zeroize/latest/zeroize crate, we can clear the memory of a new `Password` type and our `Key` types automatically when they go out of scope.

Closes #3