### PR TITLE
Proper Pinning

### DIFF
--- a/src/encrypt/key.rs
+++ b/src/encrypt/key.rs
@@ -83,13 +83,13 @@ impl<T> Key<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::encrypt::generate_salt;
+    use crate::{encrypt::generate_salt, pw};
 
     #[test]
     fn from_password() {
         let salt = generate_salt();
         let key =
-            Key::<()>::from_password("user1password".into(), &salt).expect("error generating key");
+            Key::<()>::from_password(pw!("user1password"), &salt).expect("error generating key");
         assert_eq!(256 / 8, key.0.len());
     }
 

--- a/src/encrypt/mod.rs
+++ b/src/encrypt/mod.rs
@@ -28,4 +28,4 @@ pub enum Error {
 mod key;
 pub use self::key::Key;
 mod password;
-pub use self::password::Password;
+pub use self::password::{Password, PasswordBuf};

--- a/src/encrypt/password.rs
+++ b/src/encrypt/password.rs
@@ -1,18 +1,34 @@
-use std::ops::Deref;
+use std::pin::Pin;
+use std::{marker::PhantomPinned, ops::Deref};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// A safer wrapper for plaintext password strings.
 ///
-/// This structure zeros it's memory on drop.
+/// This type both pins it's reference and zeros the memory on drop. When given
+/// a [`PasswordBuf`] it's best to immediately convert it into a [`Password`] to
+/// avoid accidental moves.
+pub type Password<'a> = Pin<&'a mut PasswordBuf>;
+
+#[macro_export]
+macro_rules! pw {
+    ($e:expr) => {
+        std::pin::pin!($crate::encrypt::PasswordBuf::from($e))
+    };
+}
+
+/// A safe wrapper for plaintext password strings.
+///
+/// This structure zeros it's memory on drop. It's safer to use a [`Password`]
+/// since it also prevents accidental moves, which may copy the memory.
 //
 // TODO: Is there a way in the GUI to avoid cloning the password to send it to
 // a async function?
 #[derive(Clone, Zeroize, ZeroizeOnDrop)]
-pub struct Password(String);
+pub struct PasswordBuf(String, PhantomPinned);
 
-impl Password {
+impl PasswordBuf {
     pub fn empty() -> Self {
-        Password(String::new())
+        PasswordBuf(String::new(), PhantomPinned)
     }
 
     pub fn as_mut(&mut self) -> &mut String {
@@ -20,30 +36,30 @@ impl Password {
     }
 }
 
-impl From<String> for Password {
+impl From<String> for PasswordBuf {
     fn from(password: String) -> Self {
-        Password(password)
+        PasswordBuf(password, PhantomPinned)
     }
 }
 
 // Only allow passwords to be created from immutable static strings when
 // testing.
 #[cfg(test)]
-impl From<&'static str> for Password {
+impl From<&'static str> for PasswordBuf {
     fn from(password: &'static str) -> Self {
-        Password(password.into())
+        PasswordBuf(password.into(), PhantomPinned)
     }
 }
 
-impl From<&mut str> for Password {
+impl From<&mut str> for PasswordBuf {
     fn from(password: &mut str) -> Self {
-        let zeroize = Password(password.into());
+        let zeroize = PasswordBuf(password.into(), PhantomPinned);
         password.zeroize();
         zeroize
     }
 }
 
-impl Deref for Password {
+impl Deref for PasswordBuf {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {

--- a/src/lot.rs
+++ b/src/lot.rs
@@ -184,7 +184,7 @@ impl From<db::Error> for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{db::Database, record::RecordData};
+    use crate::{db::Database, pw, record::RecordData};
 
     #[test]
     fn new() {
@@ -198,7 +198,7 @@ mod tests {
         let db = Database::new("sqlite://:memory:")
             .await
             .expect("failed to create database");
-        let user = User::new("nixpulvis", "password".into())
+        let user = User::new("nixpulvis", pw!("password"))
             .expect("failed to make user")
             .register(&db)
             .await
@@ -229,7 +229,7 @@ mod tests {
         let db = Database::new("sqlite://:memory:")
             .await
             .expect("failed to create database");
-        let user = User::new("nixpulvis", "password".into())
+        let user = User::new("nixpulvis", pw!("password"))
             .expect("failed to make user")
             .register(&db)
             .await
@@ -258,7 +258,7 @@ mod tests {
         let db = Database::new("sqlite://:memory:")
             .await
             .expect("failed to create database");
-        let user = User::new("nixpulvis", "password".into())
+        let user = User::new("nixpulvis", pw!("password"))
             .expect("failed to make user")
             .register(&db)
             .await
@@ -274,7 +274,7 @@ mod tests {
         let db = Database::new("sqlite://:memory:")
             .await
             .expect("failed to create database");
-        let user = User::new("nixpulvis", "password".into())
+        let user = User::new("nixpulvis", pw!("password"))
             .expect("failed to make user")
             .register(&db)
             .await

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,6 @@
 pub use crate::db::Database;
-pub use crate::encrypt::Password;
+pub use crate::encrypt::{Password, PasswordBuf};
 pub use crate::lot::{DEFAULT_LOT, Lot};
+pub use crate::pw;
 pub use crate::record::{Record, RecordData};
 pub use crate::user::User;

--- a/src/record.rs
+++ b/src/record.rs
@@ -214,7 +214,7 @@ impl From<db::Error> for Error {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{encrypt::Key, lot::Lot, user::User};
+    use crate::{encrypt::Key, lot::Lot, pw, user::User};
 
     #[test]
     fn new() {
@@ -251,7 +251,7 @@ mod tests {
         let db = Database::new("sqlite://:memory:")
             .await
             .expect("failed to create database");
-        let user = User::new("nixpulvis", "password".into())
+        let user = User::new("nixpulvis", pw!("password"))
             .expect("failed to make user")
             .register(&db)
             .await
@@ -271,7 +271,7 @@ mod tests {
         let db = Database::new("sqlite://:memory:")
             .await
             .expect("failed to create database");
-        let user = User::new("nixpulvis", "password".into())
+        let user = User::new("nixpulvis", pw!("password"))
             .expect("failed to make user")
             .register(&db)
             .await


### PR DESCRIPTION
I was mistaken in my understanding of `Pin`. I believe this fixes that, however I'm not convinced it's worth the effort. First of all, now we have two types `Password` and `PasswordBuf` to deal with. Second, uses of `PasswordBuf` are still required in the GUI and it's not at all obvious how to improve this yet. Finally, functions like `get_password` must be converted into a macro to hold ownership of the `PasswordBuf` they create before wrapping them in the `pw!` pin.

All this just to be more confident that `Zeroize` calls clear all the memory, but no guarantees. We still could have moved a `PasswordBuf` in the GUI, and there are still intermediate buffers in `get_password!`.