### PR TITLE
Add AAD Support to the Encryption

### DIFF
--- a/benches/encrypt.rs
+++ b/benches/encrypt.rs
@@ -8,11 +8,17 @@ fn keygen(c: &mut Criterion) {
 
 fn encryption(c: &mut Criterion) {
     let key = Key::<()>::generate();
-    c.bench_function("Key::encrypt", |b| {
-        b.iter(|| key.encrypt(black_box(b"plaintext")))
-    });
-    let encrypted = key.encrypt(b"plaintext").expect("failed to encrypt");
+    let encrypt = || key.encrypt(black_box(b"plaintext"));
+    c.bench_function("Key::encrypt", |b| b.iter(encrypt));
+    let encrypted = encrypt().expect("failed to encrypt");
     c.bench_function("Key::decrypt", |b| b.iter(|| key.decrypt(&encrypted)));
+
+    let encrypt_aad = || key.encrypt_with_aad(black_box(b"plaintext"), black_box(b"aad"));
+    c.bench_function("Key::encrypt_with_aad", |b| b.iter(encrypt_aad));
+    let encrypted_aad = encrypt_aad().expect("failed to encrypt");
+    c.bench_function("Key::decrypt_with_aad", |b| {
+        b.iter(|| key.decrypt_with_aad(&encrypted_aad, black_box(b"aad")))
+    });
 }
 
 criterion_group!(benches, keygen, encryption);

--- a/benches/record.rs
+++ b/benches/record.rs
@@ -1,26 +1,37 @@
 use criterion::{Criterion, criterion_group, criterion_main};
-use valet::prelude::*;
+use valet::{prelude::*, uuid::Uuid};
 
 fn small_data(c: &mut Criterion) {
     let data = RecordData::plain("label", "secret");
 
-    c.bench_function("Record::encode", |b| b.iter(|| data.encode()));
-    let encoded = data.encode();
+    let encode = || data.encode();
+    c.bench_function("Record::encode", |b| b.iter(encode));
+    let encoded = encode();
     c.bench_function("Record::decode", |b| {
         b.iter(|| RecordData::decode(&encoded))
     });
 
-    c.bench_function("Record::compress", |b| b.iter(|| data.compress()));
-    let compressed = data.compress().expect("failed to compress");
+    let compress = || data.compress();
+    c.bench_function("Record::compress", |b| b.iter(compress));
+    let compressed = compress().expect("failed to compress");
     c.bench_function("Record::decompress", |b| {
         b.iter(|| RecordData::decompress(&compressed).expect("failed to decompress"))
     });
 
     let lot = Lot::new("test");
-    c.bench_function("Record::encrypt", |b| b.iter(|| data.encrypt(lot.key())));
-    let encrypted = data.encrypt(lot.key()).expect("failed to encrypt");
+    let encrypt = || data.encrypt(lot.key());
+    c.bench_function("Record::encrypt", |b| b.iter(encrypt));
+    let encrypted = encrypt().expect("failed to encrypt");
     c.bench_function("Record::decrypt", |b| {
         b.iter(|| RecordData::decrypt(&encrypted, lot.key()))
+    });
+
+    let aad = Uuid::<Record>::now().to_string() + &Uuid::<Record>::now().to_string();
+    let encrypt_aad = || data.encrypt_with_aad(lot.key(), aad.as_bytes());
+    c.bench_function("Record::encrypt_with_aad", |b| b.iter(encrypt_aad));
+    let encrypted_aad = encrypt_aad().expect("failed to encrypt");
+    c.bench_function("Record::decrypt_with_aad", |b| {
+        b.iter(|| RecordData::decrypt_with_aad(&encrypted_aad, lot.key(), aad.as_bytes()))
     });
 }
 

--- a/src/encrypt/key.rs
+++ b/src/encrypt/key.rs
@@ -1,7 +1,7 @@
 use crate::encrypt::{Encrypted, Error, Password};
 use aes_gcm_siv::{
     Aes256GcmSiv, KeySizeUser, Nonce,
-    aead::{Aead, Key as AesKey, KeyInit, generic_array::typenum::Unsigned},
+    aead::{Aead, Key as AesKey, KeyInit, Payload, generic_array::typenum::Unsigned},
 };
 use argon2::Argon2;
 use rand_core::{OsRng, RngCore};
@@ -57,12 +57,22 @@ impl<T> Key<T> {
     }
 
     pub fn encrypt(&self, plaintext: &[u8]) -> Result<Encrypted, Error> {
+        self.encrypt_with_aad(plaintext, &[])
+    }
+
+    pub fn encrypt_with_aad(&self, plaintext: &[u8], aad: &[u8]) -> Result<Encrypted, Error> {
         let mut nonce = Nonce::default();
         OsRng.fill_bytes(&mut nonce.as_mut_slice());
 
         let cipher = Aes256GcmSiv::new(&self.0);
         let ciphertext = cipher
-            .encrypt(&nonce, plaintext)
+            .encrypt(
+                &nonce,
+                Payload {
+                    msg: plaintext,
+                    aad,
+                },
+            )
             .map_err(|e| Error::Encryption(format!("{}", e)))?;
         Ok(Encrypted {
             data: ciphertext,
@@ -71,10 +81,20 @@ impl<T> Key<T> {
     }
 
     pub fn decrypt(&self, encrypted: &Encrypted) -> Result<Vec<u8>, Error> {
+        self.decrypt_with_aad(encrypted, &[])
+    }
+
+    pub fn decrypt_with_aad(&self, encrypted: &Encrypted, aad: &[u8]) -> Result<Vec<u8>, Error> {
         let nonce = Nonce::from_slice(&encrypted.nonce);
         let cipher = Aes256GcmSiv::new(&self.0);
         let plaintext = cipher
-            .decrypt(nonce, &encrypted.data[..])
+            .decrypt(
+                nonce,
+                Payload {
+                    msg: &encrypted.data,
+                    aad,
+                },
+            )
             .map_err(|e| Error::Decryption(format!("{}", e)))?;
         Ok(plaintext)
     }

--- a/src/lot/mod.rs
+++ b/src/lot/mod.rs
@@ -88,9 +88,10 @@ impl Lot {
                 .one(db.connection())
                 .await?;
 
+        let aad = Lot::aad(user.username(), &uuid);
         match existing_ul {
             None => {
-                let encrypted = user.key().encrypt(self.key.as_bytes())?;
+                let encrypted = user.key().encrypt_with_aad(self.key.as_bytes(), &aad)?;
                 let active = self::orm::user_lots::ActiveModel {
                     username: Set(user.username().into()),
                     lot_uuid: Set(uuid),
@@ -116,7 +117,7 @@ impl Lot {
                     data: existing.data.clone(),
                     nonce: existing.nonce.clone(),
                 };
-                let existing_key_bytes = user.key().decrypt(&existing_encrypted)?;
+                let existing_key_bytes = user.key().decrypt_with_aad(&existing_encrypted, &aad)?;
                 let key_changed = existing_key_bytes != self.key.as_bytes();
 
                 let mut active = existing.into_active_model();
@@ -126,7 +127,7 @@ impl Lot {
                 }
 
                 if key_changed {
-                    let encrypted = user.key().encrypt(self.key.as_bytes())?;
+                    let encrypted = user.key().encrypt_with_aad(self.key.as_bytes(), &aad)?;
                     active.data = Set(encrypted.data);
                     active.nonce = Set(encrypted.nonce);
 
@@ -215,12 +216,17 @@ impl Lot {
             data: ul.data,
             nonce: ul.nonce,
         };
-        let key_bytes = user.key().decrypt(&encrypted)?;
+        let aad = Lot::aad(user.username(), &ul.lot_uuid);
+        let key_bytes = user.key().decrypt_with_aad(&encrypted, &aad)?;
         Ok(Lot {
             uuid: Uuid::parse(&model.uuid)?,
             name: ul.name,
             key: Key::from_bytes(&key_bytes),
         })
+    }
+
+    fn aad(username: &str, lot_uuid: &str) -> Vec<u8> {
+        [username.as_bytes(), lot_uuid.as_bytes()].concat()
     }
 }
 
@@ -447,10 +453,11 @@ mod tests {
             data: ul.data,
             nonce: ul.nonce,
         };
+        let aad = Lot::aad(user.username(), &lot.uuid().to_string());
         Key::<Lot>::from_bytes(
             &user
                 .key()
-                .decrypt(&encrypted)
+                .decrypt_with_aad(&encrypted, &aad)
                 .expect("failed to decrypted lot key"),
         )
     }

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -50,13 +50,30 @@ impl Record {
     }
 
     pub fn encrypt(&self, key: &Key<Lot>) -> Result<Encrypted, Error> {
-        self.data.encrypt(key)
+        let aad = Record::aad(&self.uuid.to_string(), &self.lot_uuid.to_string());
+        self.data.encrypt_with_aad(key, &aad)
+    }
+
+    pub fn decrypt(
+        uuid: Uuid<Self>,
+        lot_uuid: Uuid<Lot>,
+        encrypted: &Encrypted,
+        key: &Key<Lot>,
+    ) -> Result<Self, Error> {
+        let aad = Record::aad(&uuid.to_string(), &lot_uuid.to_string());
+        let data = RecordData::decrypt_with_aad(encrypted, key, &aad)?;
+        Ok(Record {
+            uuid,
+            lot_uuid,
+            data,
+        })
     }
 
     /// Save this record to the database and return its uuid.
     pub async fn upsert(&self, db: &Database, lot: &Lot) -> Result<Uuid<Self>, Error> {
         let uuid = self.uuid.clone();
-        let encrypted = self.data.encrypt(lot.key())?;
+        let aad = Record::aad(&self.uuid.to_string(), &self.lot_uuid.to_string());
+        let encrypted = self.data.encrypt_with_aad(lot.key(), &aad)?;
         // TODO: Only Set values that changed? To do this we'd need to track the
         // changed values in this Record struct... which seems redundant, since
         // the orm::ActiveModel already does that. Perhaps we can figure out a
@@ -104,16 +121,20 @@ impl Record {
                 data: model.data,
                 nonce: model.nonce,
             };
-            let data = RecordData::decrypt(&encrypted, lot.key())?;
-            let record = Record {
-                lot_uuid: lot.uuid().clone(),
-                uuid: Uuid::parse(&model.uuid)?,
-                data,
-            };
+            let record = Record::decrypt(
+                Uuid::parse(&model.uuid)?,
+                lot.uuid().clone(),
+                &encrypted,
+                lot.key(),
+            )?;
             records.push(record);
         }
 
         Ok(records)
+    }
+
+    fn aad(record_uuid: &str, lot_uuid: &str) -> Vec<u8> {
+        [record_uuid.as_bytes(), lot_uuid.as_bytes()].concat()
     }
 }
 
@@ -232,12 +253,38 @@ impl RecordData {
     }
 
     pub fn encrypt(&self, key: &Key<Lot>) -> Result<Encrypted, Error> {
+        self._encrypt(key, None)
+    }
+
+    pub fn encrypt_with_aad(&self, key: &Key<Lot>, aad: &[u8]) -> Result<Encrypted, Error> {
+        self._encrypt(key, Some(aad))
+    }
+
+    fn _encrypt(&self, key: &Key<Lot>, aad: Option<&[u8]>) -> Result<Encrypted, Error> {
         let compressed = self.compress()?;
-        key.encrypt(&compressed).map_err(|e| Error::Encryption(e))
+        if let Some(aad) = aad {
+            key.encrypt_with_aad(&compressed, aad)
+                .map_err(|e| Error::Encryption(e))
+        } else {
+            key.encrypt(&compressed).map_err(|e| Error::Encryption(e))
+        }
     }
 
     pub fn decrypt(buf: &Encrypted, key: &Key<Lot>) -> Result<Self, Error> {
-        let decrypted = key.decrypt(buf).map_err(|e| Error::Encryption(e))?;
+        Self::_decrypt(buf, key, None)
+    }
+
+    pub fn decrypt_with_aad(buf: &Encrypted, key: &Key<Lot>, aad: &[u8]) -> Result<Self, Error> {
+        Self::_decrypt(buf, key, Some(aad))
+    }
+
+    fn _decrypt(buf: &Encrypted, key: &Key<Lot>, aad: Option<&[u8]>) -> Result<Self, Error> {
+        let decrypted = if let Some(aad) = aad {
+            key.decrypt_with_aad(buf, aad)
+                .map_err(|e| Error::Encryption(e))?
+        } else {
+            key.decrypt(buf).map_err(|e| Error::Encryption(e))?
+        };
         Self::decompress(&decrypted)
     }
 }
@@ -295,15 +342,20 @@ mod tests {
         }
     }
 
-    // TODO: Record::decrypt (does #14 help get the UUID?)
     #[test]
     fn encrypt_decrypt() {
         let lot = Lot::new("test");
         let key = Key::<Lot>::generate();
         let record = Record::new(&lot, RecordData::plain("foo", "bar"));
         let encrypted = record.encrypt(&key).expect("failed to encrypt");
-        let decrypted_data = RecordData::decrypt(&encrypted, &key).expect("failed to decrypt");
-        assert_eq!(record.data, decrypted_data);
+        let decrypted = Record::decrypt(
+            record.uuid.clone(),
+            record.lot_uuid.clone(),
+            &encrypted,
+            &key,
+        )
+        .expect("failed to decrypt");
+        assert_eq!(record, decrypted);
     }
 
     #[tokio::test]
@@ -403,6 +455,19 @@ mod tests {
         let data = RecordData::plain("label", "secret");
         let encrypted = data.encrypt(lot.key()).expect("failed to encrypt");
         let decrypted = RecordData::decrypt(&encrypted, lot.key()).expect("failed to decrypt");
+        assert_eq!(data, decrypted);
+    }
+
+    #[test]
+    fn data_encrypt_decrypt_with_aad() {
+        let lot = Lot::new("test");
+        let data = RecordData::plain("label", "secret");
+        let aad = [1, 2, 3];
+        let encrypted = data
+            .encrypt_with_aad(lot.key(), &aad)
+            .expect("failed to encrypt");
+        let decrypted =
+            RecordData::decrypt_with_aad(&encrypted, lot.key(), &aad).expect("failed to decrypt");
         assert_eq!(data, decrypted);
     }
 }

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -23,7 +23,7 @@ const VALIDATION: &[u8] = b"VALID";
 ///
 /// In addition to the salt, each user also stores a short encrypted validation
 /// string which is used to authenticate the user. Simply being able
-/// to decrpyt the string is enough to verify the user, since we use
+/// to decrypt the string is enough to verify the user, since we use
 /// ["Authenticated Encryption"][2] (the AE in AEAD).
 ///
 /// [1]: https://en.wikipedia.org/wiki/Rainbow_table
@@ -41,7 +41,7 @@ impl User {
     pub fn new(username: &str, password: Password) -> Result<Self, Error> {
         let salt = encrypt::generate_salt();
         let key = Key::from_password(password, &salt)?;
-        let validation = key.encrypt(VALIDATION)?;
+        let validation = key.encrypt_with_aad(VALIDATION, User::aad(username))?;
         Ok(User {
             username: username.into(),
             salt,
@@ -72,7 +72,10 @@ impl User {
     }
 
     pub fn validate(&self) -> bool {
-        if let Ok(v) = self.key().decrypt(&self.validation) {
+        if let Ok(v) = self
+            .key()
+            .decrypt_with_aad(&self.validation, User::aad(&self.username))
+        {
             v == VALIDATION // This should never be false.
         } else {
             false
@@ -127,6 +130,10 @@ impl User {
             .all(db.connection())
             .await
             .map_err(Into::into)
+    }
+
+    fn aad(username: &str) -> &[u8] {
+        username.as_bytes()
     }
 }
 


### PR DESCRIPTION
This prevents attackers from swapping data and possibly tricking users into misusing thier keys to decrypt different data.

Closes #14