### PR TITLE
Add password validation for user and record creation

### DIFF
--- a/benches/record.rs
+++ b/benches/record.rs
@@ -5,7 +5,7 @@ fn small_data(c: &mut Criterion) {
     let data = Data::new(
         Label::Simple("label".to_string()),
         "secret".try_into().unwrap(),
-    );
+    ).expect("password validation failed");
 
     let encode = || data.encode();
     c.bench_function("Record::encode", |b| b.iter(encode));

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -229,10 +229,17 @@ async fn main() -> Result<(), valet::user::Error> {
                                     // TODO: Delete old record if it exists.
                                     // TODO: Add deleted record to new record's history.
                                     // TODO: Put data in a Password itself.
-                                    Record::new(&lot, Data::new(label, password))
-                                        .upsert(&db, &lot)
-                                        .await
-                                        .expect("failed to save record");
+                                    match Data::new(label, password) {
+                                        Ok(data) => {
+                                            Record::new(&lot, data)
+                                                .upsert(&db, &lot)
+                                                .await
+                                                .expect("failed to save record");
+                                        }
+                                        Err(_) => {
+                                            println!("Invalid password");
+                                        }
+                                    }
                                 } else {
                                     println!("Invalid password");
                                 }
@@ -463,23 +470,27 @@ async fn import_apple(db: &Database, lot: &mut Lot, path: &str) {
                     .as_str()
                     .try_into()
                 {
-                    match Record::new(
-                        &lot,
-                        Data::new(Label::Simple(label.clone()), password).with_extra(data),
-                    )
-                    .upsert(&db, lot)
-                    .await
-                    {
-                        Ok(uuid) => {
-                            println!(
-                                "Inserted {}::{} <{}>",
-                                lot.name(),
-                                label,
-                                uuid.to_uuid().as_hyphenated()
-                            )
+                    match Data::new(Label::Simple(label.clone()), password) {
+                        Ok(data_item) => {
+                            match Record::new(&lot, data_item.with_extra(data))
+                                .upsert(&db, lot)
+                                .await
+                            {
+                                Ok(uuid) => {
+                                    println!(
+                                        "Inserted {}::{} <{}>",
+                                        lot.name(),
+                                        label,
+                                        uuid.to_uuid().as_hyphenated()
+                                    );
+                                }
+                                Err(e) => {
+                                    dbg!(e);
+                                }
+                            }
                         }
-                        Err(e) => {
-                            dbg!(e);
+                        Err(_) => {
+                            println!("Invalid password");
                         }
                     }
                 }

--- a/src/bin/gui/view/primary/unlocked.rs
+++ b/src/bin/gui/view/primary/unlocked.rs
@@ -171,10 +171,17 @@ impl<'a> View for Unlocked<'a> {
                                         match Label::from_str(&new_label) {
                                             Ok(label) => {
                                                 // TODO: Add deleted record to new record's history.
-                                                Record::new(&lot, Data::new(label, new_password))
-                                                    .upsert(&db, &lot)
-                                                    .await
-                                                    .expect("failed to save record");
+                                                match Data::new(label, new_password) {
+                                                    Ok(data) => {
+                                                        Record::new(&lot, data)
+                                                            .upsert(&db, &lot)
+                                                            .await
+                                                            .expect("failed to save record");
+                                                    }
+                                                    Err(_) => {
+                                                        // Password validation failed
+                                                    }
+                                                }
                                             }
                                             Err(error) => {
                                                 // TODO: We need error flashes in the UI.

--- a/src/lot/mod.rs
+++ b/src/lot/mod.rs
@@ -330,14 +330,14 @@ mod tests {
         lot_a.save(&db, &user).await.expect("failed to save lot");
         Record::new(
             &lot_a,
-            Data::new(Label::Simple("a".into()), "1".try_into().unwrap()),
+            Data::new(Label::Simple("a".into()), "password1".try_into().unwrap()).unwrap(),
         )
         .upsert(&db, &lot_a)
         .await
         .expect("failed to upsert record");
         Record::new(
             &lot_a,
-            Data::new(Label::Simple("b".into()), "2".try_into().unwrap()),
+            Data::new(Label::Simple("b".into()), "password2".try_into().unwrap()).unwrap(),
         )
         .upsert(&db, &lot_a)
         .await
@@ -366,7 +366,7 @@ mod tests {
         lot_a.save(&db, &user).await.expect("failed to save lot");
         Record::new(
             &lot_a,
-            Data::new(Label::Simple("a".into()), "1".try_into().unwrap()),
+            Data::new(Label::Simple("a".into()), "password1".try_into().unwrap()).unwrap(),
         )
         .upsert(&db, &lot_a)
         .await
@@ -375,7 +375,7 @@ mod tests {
         lot_b.save(&db, &user).await.expect("failed to save lot");
         Record::new(
             &lot_b,
-            Data::new(Label::Simple("b".into()), "2".try_into().unwrap()),
+            Data::new(Label::Simple("b".into()), "password2".try_into().unwrap()).unwrap(),
         )
         .upsert(&db, &lot_b)
         .await
@@ -417,7 +417,7 @@ mod tests {
         lot.save(&db, &user).await.expect("failed to save lot");
         Record::new(
             &lot,
-            Data::new(Label::Simple("a".into()), "1".try_into().unwrap()),
+            Data::new(Label::Simple("a".into()), "password1".try_into().unwrap()).unwrap(),
         )
         .upsert(&db, &lot)
         .await
@@ -452,7 +452,7 @@ mod tests {
         lot.save(&db, &user).await.expect("failed to save lot");
         Record::new(
             &lot,
-            Data::new(Label::Simple("a".into()), "1".try_into().unwrap()),
+            Data::new(Label::Simple("a".into()), "password1".try_into().unwrap()).unwrap(),
         )
         .upsert(&db, &lot)
         .await

--- a/src/record/data/mod.rs
+++ b/src/record/data/mod.rs
@@ -21,12 +21,15 @@ impl fmt::Display for Data {
 }
 
 impl Data {
-    pub fn new(label: Label, password: Password) -> Self {
-        Data {
+    pub fn new(label: Label, password: Password) -> Result<Self, Error> {
+        if !password.is_valid() {
+            return Err(Error::InvalidPassword);
+        }
+        Ok(Data {
             label,
             password,
             extra: HashMap::new(),
-        }
+        })
     }
 
     pub fn add_extra(mut self, attr: String, value: String) -> Self {
@@ -122,13 +125,14 @@ mod tests {
 
     #[test]
     fn label() {
-        let data = Data::new(Label::Simple("label".into()), "secret".try_into().unwrap());
+        let data = Data::new(Label::Simple("label".into()), "secretpass".try_into().unwrap()).unwrap();
         assert_eq!("label", format!("{}", data.label()));
     }
 
     #[test]
     fn extra() {
-        let data = Data::new(Label::Simple("label".into()), "secret".try_into().unwrap())
+        let data = Data::new(Label::Simple("label".into()), "secretpass".try_into().unwrap())
+            .unwrap()
             .add_extra("foo".into(), "bar".into())
             .add_extra("foo".into(), "bar".into());
         assert_eq!(data.extra.len(), 1);
@@ -137,7 +141,7 @@ mod tests {
 
     #[test]
     fn encode_decode() {
-        let data = Data::new(Label::Simple("label".into()), "secret".try_into().unwrap());
+        let data = Data::new(Label::Simple("label".into()), "secretpass".try_into().unwrap()).unwrap();
         let encoded = data.encode();
         let decoded = Data::decode(&encoded).expect("failed to decode");
         assert_eq!(data, decoded);
@@ -145,7 +149,7 @@ mod tests {
 
     #[test]
     fn compress_decompress() {
-        let data = Data::new(Label::Simple("label".into()), "secret".try_into().unwrap());
+        let data = Data::new(Label::Simple("label".into()), "secretpass".try_into().unwrap()).unwrap();
         let compressed = data.compress().expect("failed to compress");
         let decompressed = Data::decompress(&compressed).expect("failed to decompress");
         assert_eq!(data, decompressed);
@@ -154,7 +158,7 @@ mod tests {
     #[test]
     fn encrypt_decrypt() {
         let lot = Lot::new("test");
-        let data = Data::new(Label::Simple("label".into()), "secret".try_into().unwrap());
+        let data = Data::new(Label::Simple("label".into()), "secretpass".try_into().unwrap()).unwrap();
         let encrypted = data.encrypt(lot.key()).expect("failed to encrypt");
         let decrypted = Data::decrypt(&encrypted, lot.key()).expect("failed to decrypt");
         assert_eq!(data, decrypted);
@@ -163,7 +167,7 @@ mod tests {
     #[test]
     fn encrypt_decrypt_with_aad() {
         let lot = Lot::new("test");
-        let data = Data::new(Label::Simple("label".into()), "secret".try_into().unwrap());
+        let data = Data::new(Label::Simple("label".into()), "secretpass".try_into().unwrap()).unwrap();
         let aad = [1, 2, 3];
         let encrypted = data
             .encrypt_with_aad(lot.key(), &aad)
@@ -171,5 +175,12 @@ mod tests {
         let decrypted =
             Data::decrypt_with_aad(&encrypted, lot.key(), &aad).expect("failed to decrypt");
         assert_eq!(data, decrypted);
+    }
+
+    #[test]
+    fn new_rejects_invalid_password() {
+        let invalid_password: Password = "short".try_into().unwrap();
+        let result = Data::new(Label::Simple("label".into()), invalid_password);
+        assert!(matches!(result, Err(Error::InvalidPassword)));
     }
 }

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -165,6 +165,7 @@ impl fmt::Debug for Record {
 #[derive(Debug)]
 pub enum Error {
     MissingLot,
+    InvalidPassword,
     Uuid(crate::uuid::Error),
     #[cfg(feature = "db")]
     Database(db::Error),
@@ -214,12 +215,12 @@ mod tests {
         let lot = Lot::new("test");
         let record = Record::new(
             &lot,
-            Data::new(Label::Simple("foo".into()), "bar".try_into().unwrap()),
+            Data::new(Label::Simple("foo".into()), "barpassword".try_into().unwrap()).unwrap(),
         );
         assert_eq!(lot.uuid(), &record.lot_uuid);
         assert_eq!(36, record.uuid.to_string().len());
         assert_eq!(record.data.label(), &Label::Simple("foo".into()));
-        assert_eq!(record.data.password().to_string(), "bar");
+        assert_eq!(record.data.password().to_string(), "barpassword");
     }
 
     #[test]
@@ -227,7 +228,7 @@ mod tests {
         let lot = Lot::new("test");
         let record = Record::new(
             &lot,
-            Data::new(Label::Simple("foo".into()), "bar".try_into().unwrap()),
+            Data::new(Label::Simple("foo".into()), "barpassword".try_into().unwrap()).unwrap(),
         );
         let encrypted = record.encrypt(&lot.key()).expect("failed to encrypt");
         let decrypted = Record::decrypt(
@@ -255,7 +256,7 @@ mod tests {
         lot.save(&db, &user).await.expect("failed to save lot");
         let inserted_uuid = Record::new(
             &lot,
-            Data::new(Label::Simple("foo".into()), "bar".try_into().unwrap()),
+            Data::new(Label::Simple("foo".into()), "barpassword".try_into().unwrap()).unwrap(),
         )
         .upsert(&db, &lot)
         .await
@@ -280,7 +281,7 @@ mod tests {
         lot.save(&db, &user).await.expect("failed to save lot");
         let record = Record::new(
             &lot,
-            Data::new(Label::Simple("foo".into()), "bar".try_into().unwrap()),
+            Data::new(Label::Simple("foo".into()), "barpassword".try_into().unwrap()).unwrap(),
         );
         let inserted_uuid = record
             .upsert(&db, &lot)
@@ -308,7 +309,7 @@ mod tests {
         lot.save(&db, &user).await.expect("failed to save lot");
         let record = Record::new(
             &lot,
-            Data::new(Label::Simple("foo".into()), "bar".try_into().unwrap()),
+            Data::new(Label::Simple("foo".into()), "barpassword".try_into().unwrap()).unwrap(),
         );
         record
             .upsert(&db, &lot)

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -43,6 +43,9 @@ pub struct User {
 
 impl User {
     pub fn new(username: &str, password: Password) -> Result<Self, Error> {
+        if !password.is_valid() {
+            return Err(Error::InvalidPassword);
+        }
         let salt = encrypt::generate_salt();
         let key = Key::from_password(&password, &salt)?;
         let validation = key.encrypt_with_aad(VALIDATION, User::aad(username))?;
@@ -157,6 +160,7 @@ impl Debug for User {
 pub enum Error {
     NotFound,
     Invalid,
+    InvalidPassword,
     SaltError,
     Encrypt(encrypt::Error),
     #[cfg(feature = "db")]
@@ -229,6 +233,13 @@ mod tests {
         User::new("alice", "password".try_into().unwrap()).expect("failed to create user");
         let duration = start.elapsed();
         assert!(duration > Duration::from_millis(200));
+    }
+
+    #[test]
+    fn new_rejects_invalid_password() {
+        let invalid_password: Password = "short".try_into().unwrap();
+        let result = User::new("alice", invalid_password);
+        assert!(matches!(result, Err(Error::InvalidPassword)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Enforce password validation by checking password is valid (minimum 8 characters)
when creating new users or records. This ensures weak passwords cannot be used
to protect sensitive data.

Changes:
- User::new() now validates password and returns InvalidPassword error if invalid
- Data::new() now validates password and returns InvalidPassword error if invalid
- Updated all call sites to handle the Result returned by Data::new()
- Added tests to verify password validation is working correctly
- Updated all test passwords to meet minimum length requirement

https://claude.ai/code/session_013bvovYCnLR7R7UStDzy7vN